### PR TITLE
feat: Use Go version from go.mod

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,12 +18,9 @@ runs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: '1'
     - name: 'Setup Golang'
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
-    - name: 'Generate coverage A'
-      shell: bash
-      run: paste go.mod go.sum
+        go-version-file: go.mod
     - name: 'Generate coverage A'
       shell: bash
       run: go test -cover ./... | grep -v "no test files" | awk '{printf "%s a %d\n", $2, $5}' | sed -e 's/%//' > a.cover


### PR DESCRIPTION
I think it's fairly safe to use the top level go.mod path.
I've also removed a step performing the `paste`, I think it was there for experimentation/debugging and is no longer needed.